### PR TITLE
Set up RTD hosting

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,0 +1,16 @@
+name: Check links
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    uses: access-nri/documentation-infra/.github/workflows/check_links_workflow.yml@v0.3
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      commit: ${{ github.event.pull_request.head.sha || github.sha }}
+      rtd_project: 'access-am3-configs'

--- a/documentation/.readthedocs.yaml
+++ b/documentation/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# ReadtheDocs config version
+version: 2
+
+# Set the ReadtheDocs Docker image OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+  jobs:
+    # Set pip settings for safety on newly-published dependencies
+    post_create_environment:
+      - mkdir -p "$HOME/.config/pip"
+      - printf "[global]\nuploaded-prior-to = P7D\n" > "$HOME/.config/pip/pip.conf"
+
+# Build documentation with Mkdocs
+mkdocs:
+  configuration: documentation/mkdocs.yml
+
+# Python requirements to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: documentation/requirements.txt


### PR DESCRIPTION
Added the following files for the website documentation setup through Read The Docs:
- `.readthedocs.yaml` -> Main RTD configuration
- `.github/workflows/check_links.yml` -> link checker

> [!NOTE]
> The link check and RTD build is currently failing because the `.readthedocs.yaml` configuration file is not present in the `main` branch. 
> As soon as this PR gets merged, the whole setup will work as expected.